### PR TITLE
Reduce Google Drive permissions scope

### DIFF
--- a/src/sync_backend_clients/google_drive_sync_backend_client.js
+++ b/src/sync_backend_clients/google_drive_sync_backend_client.js
@@ -11,7 +11,7 @@ export default () => {
           .init({
             client_id: process.env.REACT_APP_GOOGLE_DRIVE_CLIENT_ID,
             discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
-            scope: 'https://www.googleapis.com/auth/drive',
+            scope: 'https://www.googleapis.com/auth/drive.file',
           })
           .then(resolve);
       })


### PR DESCRIPTION
The discussion on HN[1] included a suggestion to restrict the scope from all access to all google drive files, which is
to unrestricted, to a scope which only includes "View and manage Google Drive files and folders that you have opened or created with this app". [2]

[1] https://news.ycombinator.com/item?id=20480983
[2] https://developers.google.com/drive/api/v2/about-auth